### PR TITLE
Add subnet wildcard feature for dynamic IP octet replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Optional arguments:
 - `--debug`: Enable debug output
 - `--api-version`: API version to use (default: v13_0)
 - `--show-domains`: Show available domains
+- `--wildcard`: Replace X in IP addresses with specified octet value (0-255). For example, `--wildcard 48` will replace "10.X.200.128" with "10.48.200.128"
 
 ### Retrieving L3 ACL Policies
 
@@ -175,6 +176,27 @@ Here's an example of a JSON rules file that can be used with the `--rule-file` p
     "direction": "INBOUND"
   }
 ]
+```
+
+### Wildcard Feature
+
+The `--wildcard` option allows you to use placeholder IP addresses in your rules and replace them with a specific octet at runtime. This is useful when managing ACL policies across multiple networks with similar structure but different subnet identifiers.
+
+#### How it works:
+- Use "X" (uppercase or lowercase) as a placeholder in IP addresses in your rule files
+- Specify the replacement octet value with `--wildcard` (0-255)
+- All instances of "X" or "x" in source and destination IP addresses will be replaced
+
+#### Example:
+```csv
+description,protocol,action,direction,sourceIp,sourceIpMask,enableSourceIpSubnet,destinationIp,destinationIpMask,enableDestinationIpSubnet,sourceMinPort,sourceMaxPort,enableSourcePortRange,destinationMinPort,destinationMaxPort,enableDestinationPortRange,customProtocol
+Proxies_new,TCP,ALLOW,INBOUND,,,FALSE,10.x.200.128,,FALSE,,,FALSE,8080,,FALSE,
+```
+
+When using `--wildcard 48`, the destination IP "10.x.200.128" becomes "10.48.200.128".
+
+```bash
+python create_l3_acl.py --host <hostname> --username <username> --password <password> --name "Network-48-Policy" --rule-file rules.csv --wildcard 48
 ```
 
 ## Example Script

--- a/test_wildcard.py
+++ b/test_wildcard.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Test script for the wildcard feature in create_l3_acl.py
+"""
+
+import json
+
+# Test data with X placeholders
+test_rules = [
+    {
+        "description": "Test rule with wildcard in source IP",
+        "protocol": "TCP",
+        "action": "ALLOW",
+        "direction": "INBOUND",
+        "sourceIp": "10.X.100.0",
+        "sourceIpMask": "255.255.255.0",
+        "enableSourceIpSubnet": True,
+        "destinationIp": "192.168.1.0",
+        "destinationIpMask": "255.255.255.0",
+        "enableDestinationIpSubnet": True
+    },
+    {
+        "description": "Test rule with wildcard in destination IP",
+        "protocol": "TCP",
+        "action": "ALLOW",
+        "direction": "INBOUND",
+        "sourceIp": "192.168.1.0",
+        "sourceIpMask": "255.255.255.0",
+        "enableSourceIpSubnet": True,
+        "destinationIp": "10.x.200.128",
+        "destinationIpMask": "255.255.255.255",
+        "enableDestinationIpSubnet": False,
+        "destinationMinPort": 8080,
+        "destinationMaxPort": 8080,
+        "enableDestinationPortRange": False
+    },
+    {
+        "description": "Test rule with wildcard in both IPs",
+        "protocol": "UDP",
+        "action": "ALLOW",
+        "direction": "DUAL",
+        "sourceIp": "172.X.0.0",
+        "sourceIpMask": "255.255.0.0",
+        "enableSourceIpSubnet": True,
+        "destinationIp": "172.X.100.0",
+        "destinationIpMask": "255.255.255.0",
+        "enableDestinationIpSubnet": True
+    },
+    {
+        "description": "Test rule without wildcards",
+        "protocol": "TCP",
+        "action": "ALLOW",
+        "direction": "INBOUND",
+        "sourceIp": "10.0.0.0",
+        "sourceIpMask": "255.0.0.0",
+        "enableSourceIpSubnet": True,
+        "destinationIp": "192.168.10.0",
+        "destinationIpMask": "255.255.255.0",
+        "enableDestinationIpSubnet": True
+    }
+]
+
+# Save test rules to a JSON file
+with open('test_wildcard_rules.json', 'w') as f:
+    json.dump(test_rules, f, indent=2)
+
+print("Test wildcard rules saved to test_wildcard_rules.json")
+print("\nExample usage:")
+print("python create_l3_acl.py --host <host> --username <user> --password <pass> --name 'Test Wildcard Policy' --rule-file test_wildcard_rules.json --wildcard 48")
+print("\nThis will replace all 'X' with '48' in the IP addresses:")
+print("  10.X.100.0 -> 10.48.100.0")
+print("  10.x.200.128 -> 10.48.200.128")
+print("  172.X.0.0 -> 172.48.0.0")
+print("  172.X.100.0 -> 172.48.100.0")

--- a/test_wildcard_rules.csv
+++ b/test_wildcard_rules.csv
@@ -1,0 +1,4 @@
+description,protocol,action,direction,sourceIp,sourceIpMask,enableSourceIpSubnet,destinationIp,destinationIpMask,enableDestinationIpSubnet,sourceMinPort,sourceMaxPort,enableSourcePortRange,destinationMinPort,destinationMaxPort,enableDestinationPortRange,customProtocol
+Test wildcard subnet,TCP,ALLOW,INBOUND,,,FALSE,10.x.200.128,,FALSE,,,FALSE,8080,,FALSE,
+Test wildcard source,TCP,ALLOW,DUAL,172.X.0.0,255.255.0.0,TRUE,192.168.1.0,255.255.255.0,TRUE,,,FALSE,,,FALSE,
+Test wildcard both IPs,UDP,ALLOW,DUAL,10.X.100.0,255.255.255.0,TRUE,10.X.200.0,255.255.255.0,TRUE,,,FALSE,,,FALSE,

--- a/test_wildcard_rules.json
+++ b/test_wildcard_rules.json
@@ -1,0 +1,53 @@
+[
+  {
+    "description": "Test rule with wildcard in source IP",
+    "protocol": "TCP",
+    "action": "ALLOW",
+    "direction": "INBOUND",
+    "sourceIp": "10.X.100.0",
+    "sourceIpMask": "255.255.255.0",
+    "enableSourceIpSubnet": true,
+    "destinationIp": "192.168.1.0",
+    "destinationIpMask": "255.255.255.0",
+    "enableDestinationIpSubnet": true
+  },
+  {
+    "description": "Test rule with wildcard in destination IP",
+    "protocol": "TCP",
+    "action": "ALLOW",
+    "direction": "INBOUND",
+    "sourceIp": "192.168.1.0",
+    "sourceIpMask": "255.255.255.0",
+    "enableSourceIpSubnet": true,
+    "destinationIp": "10.x.200.128",
+    "destinationIpMask": "255.255.255.255",
+    "enableDestinationIpSubnet": false,
+    "destinationMinPort": 8080,
+    "destinationMaxPort": 8080,
+    "enableDestinationPortRange": false
+  },
+  {
+    "description": "Test rule with wildcard in both IPs",
+    "protocol": "UDP",
+    "action": "ALLOW",
+    "direction": "DUAL",
+    "sourceIp": "172.X.0.0",
+    "sourceIpMask": "255.255.0.0",
+    "enableSourceIpSubnet": true,
+    "destinationIp": "172.X.100.0",
+    "destinationIpMask": "255.255.255.0",
+    "enableDestinationIpSubnet": true
+  },
+  {
+    "description": "Test rule without wildcards",
+    "protocol": "TCP",
+    "action": "ALLOW",
+    "direction": "INBOUND",
+    "sourceIp": "10.0.0.0",
+    "sourceIpMask": "255.0.0.0",
+    "enableSourceIpSubnet": true,
+    "destinationIp": "192.168.10.0",
+    "destinationIpMask": "255.255.255.0",
+    "enableDestinationIpSubnet": true
+  }
+]


### PR DESCRIPTION
## Summary
- Added a `--wildcard` CLI argument that replaces 'X' in IP addresses with a specific octet value
- Allows reusing the same rule templates across multiple networks with different subnet numbering
- Added test files and documentation for the feature

## Test plan
- Run `python3 test_wildcard.py` to create test files
- Test with CSV format: `python3 create_l3_acl.py --host <host> --user <user> --pass <pass> --name "Test" --rule-file test_wildcard_rules.csv --wildcard 42`
- Test with JSON format: `python3 create_l3_acl.py --host <host> --user <user> --pass <pass> --name "Test" --rule-file test_wildcard_rules.json --wildcard 42`
- Verify that "X" is replaced with the specified octet in IP addresses