### PR TITLE
Add --wildcard-file for bulk ACL policy creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ The `--wildcard-file` option allows you to create multiple ACL policies from a s
 ##### Wildcard File Format:
 ```csv
 name,octet
-"Site A",10
-"Site B",20
-"Site C",30
+"test1",10
+"test2",20
+"test3",30
 ```
 
 ##### Example:
@@ -226,9 +226,9 @@ python create_l3_acl.py --host <hostname> --username <username> --password <pass
 ```
 
 This will create three policies:
-- "Site A" with octet value 10 (replacing all "X" with "10")
-- "Site B" with octet value 20 (replacing all "X" with "20")
-- "Site C" with octet value 30 (replacing all "X" with "30")
+- "test1" with octet value 10 (replacing all "X" with "10")
+- "test2" with octet value 20 (replacing all "X" with "20")
+- "test3" with octet value 30 (replacing all "X" with "30")
 
 The feature allows efficient deployment of standardized ACL policies across multiple sites with different subnet numbering.
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Optional arguments:
 - `--api-version`: API version to use (default: v13_0)
 - `--show-domains`: Show available domains
 - `--wildcard`: Replace X in IP addresses with specified octet value (0-255). For example, `--wildcard 48` will replace "10.X.200.128" with "10.48.200.128"
+- `--wildcard-file`: CSV file with site names and octets (format: name,octet). Creates multiple policies, one for each site in the file. When using this option, `--name` is not required.
 
 ### Retrieving L3 ACL Policies
 
@@ -180,14 +181,16 @@ Here's an example of a JSON rules file that can be used with the `--rule-file` p
 
 ### Wildcard Feature
 
-The `--wildcard` option allows you to use placeholder IP addresses in your rules and replace them with a specific octet at runtime. This is useful when managing ACL policies across multiple networks with similar structure but different subnet identifiers.
+The `--wildcard` and `--wildcard-file` options allow you to use placeholder IP addresses in your rules and replace them with specific octet values at runtime. This is useful when managing ACL policies across multiple networks with similar structure but different subnet identifiers.
 
-#### How it works:
+#### Single Wildcard Replacement
+
+##### How it works:
 - Use "X" (uppercase or lowercase) as a placeholder in IP addresses in your rule files
 - Specify the replacement octet value with `--wildcard` (0-255)
 - All instances of "X" or "x" in source and destination IP addresses will be replaced
 
-#### Example:
+##### Example:
 ```csv
 description,protocol,action,direction,sourceIp,sourceIpMask,enableSourceIpSubnet,destinationIp,destinationIpMask,enableDestinationIpSubnet,sourceMinPort,sourceMaxPort,enableSourcePortRange,destinationMinPort,destinationMaxPort,enableDestinationPortRange,customProtocol
 Proxies_new,TCP,ALLOW,INBOUND,,,FALSE,10.x.200.128,,FALSE,,,FALSE,8080,,FALSE,
@@ -198,6 +201,36 @@ When using `--wildcard 48`, the destination IP "10.x.200.128" becomes "10.48.200
 ```bash
 python create_l3_acl.py --host <hostname> --username <username> --password <password> --name "Network-48-Policy" --rule-file rules.csv --wildcard 48
 ```
+
+#### Bulk Wildcard Replacement
+
+The `--wildcard-file` option allows you to create multiple ACL policies from a single template, each with different octet values and policy names.
+
+##### How it works:
+- Create a CSV file with two columns: `name` and `octet`
+- Each row represents a site with its name and octet value
+- The script creates one policy per row, using the site name as the policy name and the octet value for replacement
+- When using `--wildcard-file`, the `--name` parameter is not required (and will be ignored)
+
+##### Wildcard File Format:
+```csv
+name,octet
+"Site A",10
+"Site B",20
+"Site C",30
+```
+
+##### Example:
+```bash
+python create_l3_acl.py --host <hostname> --username <username> --password <password> --rule-file rules.csv --wildcard-file sites.csv
+```
+
+This will create three policies:
+- "Site A" with octet value 10 (replacing all "X" with "10")
+- "Site B" with octet value 20 (replacing all "X" with "20")
+- "Site C" with octet value 30 (replacing all "X" with "30")
+
+The feature allows efficient deployment of standardized ACL policies across multiple sites with different subnet numbering.
 
 ## Example Script
 

--- a/test_wildcard_file.py
+++ b/test_wildcard_file.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Test script for the wildcard file feature in create_l3_acl.py
+"""
+
+import json
+import os
+
+# Test data with X placeholders (same as in test_wildcard.py)
+test_rules = [
+    {
+        "description": "Test rule with wildcard in source IP",
+        "protocol": "TCP",
+        "action": "ALLOW",
+        "direction": "INBOUND",
+        "sourceIp": "10.X.100.0",
+        "sourceIpMask": "255.255.255.0",
+        "enableSourceIpSubnet": True,
+        "destinationIp": "192.168.1.0",
+        "destinationIpMask": "255.255.255.0",
+        "enableDestinationIpSubnet": True
+    },
+    {
+        "description": "Test rule with wildcard in destination IP",
+        "protocol": "TCP",
+        "action": "ALLOW",
+        "direction": "INBOUND",
+        "sourceIp": "192.168.1.0",
+        "sourceIpMask": "255.255.255.0",
+        "enableSourceIpSubnet": True,
+        "destinationIp": "10.x.200.128",
+        "destinationIpMask": "255.255.255.255",
+        "enableDestinationIpSubnet": False,
+        "destinationMinPort": 8080,
+        "destinationMaxPort": 8080,
+        "enableDestinationPortRange": False
+    },
+    {
+        "description": "Test rule with wildcard in both IPs",
+        "protocol": "UDP",
+        "action": "ALLOW",
+        "direction": "DUAL",
+        "sourceIp": "172.X.0.0",
+        "sourceIpMask": "255.255.0.0",
+        "enableSourceIpSubnet": True,
+        "destinationIp": "172.X.100.0",
+        "destinationIpMask": "255.255.255.0",
+        "enableDestinationIpSubnet": True
+    }
+]
+
+# Save test rules to a JSON file
+with open('test_wildcard_rules.json', 'w') as f:
+    json.dump(test_rules, f, indent=2)
+
+print("Test wildcard rules saved to test_wildcard_rules.json")
+print("Wildcard site files are available at:")
+print("  - wildcard_sites_numeric.csv: 42 sites with numeric octets")
+print("  - wildcard_sites_alpha.csv: 3 sites (A, B, C) with octets 10, 20, 30")
+
+print("\nExample usage with wildcard-file:")
+print("python create_l3_acl.py --host <host> --username <user> --password <pass> --rule-file test_wildcard_rules.json --wildcard-file wildcard_sites_alpha.csv")
+print("\nThis will create 3 policies:")
+print("  - 'Site A' with octet 10")
+print("  - 'Site B' with octet 20")
+print("  - 'Site C' with octet 30")
+
+print("\nOr using the large site list:")
+print("python create_l3_acl.py --host <host> --username <user> --password <pass> --rule-file test_wildcard_rules.json --wildcard-file wildcard_sites_numeric.csv")
+print("This will create 42 policies, one for each site in the wildcard file.")

--- a/test_wildcard_file.py
+++ b/test_wildcard_file.py
@@ -56,14 +56,14 @@ with open('test_wildcard_rules.json', 'w') as f:
 print("Test wildcard rules saved to test_wildcard_rules.json")
 print("Wildcard site files are available at:")
 print("  - wildcard_sites_numeric.csv: 42 sites with numeric octets")
-print("  - wildcard_sites_alpha.csv: 3 sites (A, B, C) with octets 10, 20, 30")
+print("  - wildcard_sites_alpha.csv: 3 sites (test1, test2, test3) with octets 10, 20, 30")
 
 print("\nExample usage with wildcard-file:")
 print("python create_l3_acl.py --host <host> --username <user> --password <pass> --rule-file test_wildcard_rules.json --wildcard-file wildcard_sites_alpha.csv")
 print("\nThis will create 3 policies:")
-print("  - 'Site A' with octet 10")
-print("  - 'Site B' with octet 20")
-print("  - 'Site C' with octet 30")
+print("  - 'test1' with octet 10")
+print("  - 'test2' with octet 20")
+print("  - 'test3' with octet 30")
 
 print("\nOr using the large site list:")
 print("python create_l3_acl.py --host <host> --username <user> --password <pass> --rule-file test_wildcard_rules.json --wildcard-file wildcard_sites_numeric.csv")

--- a/wildcard_sites_alpha.csv
+++ b/wildcard_sites_alpha.csv
@@ -1,4 +1,4 @@
 name,octet
-"Site A",10
-"Site B",20
-"Site C",30
+"test1",10
+"test2",20
+"test3",30

--- a/wildcard_sites_alpha.csv
+++ b/wildcard_sites_alpha.csv
@@ -1,0 +1,4 @@
+name,octet
+"Site A",10
+"Site B",20
+"Site C",30


### PR DESCRIPTION
## Summary
- Added a new `--wildcard-file` parameter that accepts a CSV file with site names and octet values
- Script creates multiple ACL policies from a single rule template, one for each site in the CSV file
- Each site entry provides the policy name and octet value for IP address wildcards
- Made the `--name` parameter optional when using `--wildcard-file`
- Improved filename handling for generated policy files to use the policy name

## Test plan
- Run `python3 test_wildcard_file.py` to create test files
- Test with included example file: `python3 create_l3_acl.py --host <host> --user <user> --pass <pass> --rule-file test_wildcard_rules.json --wildcard-file wildcard_sites_alpha.csv`
- Verify that multiple policies are created, one for each site in the CSV
- Verify that each policy uses the site name and correctly replaces "X" in IP addresses with the site's octet value