### PR TITLE
fix: Fix Google Cloud deployment configuration

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -51,7 +51,6 @@ CLAUDE.md
 
 # Scripts not needed for web app
 create_l3_acl.py
-create_firewall_profile.py
 retrieve_l3_acls.py
 deploy.sh
 

--- a/app.yaml
+++ b/app.yaml
@@ -4,6 +4,9 @@ runtime: python39
 # Instance class - using F1 (free tier eligible)
 instance_class: F1
 
+# Entrypoint
+entrypoint: gunicorn -b :$PORT main:app
+
 # Automatic scaling settings for free tier
 automatic_scaling:
   max_instances: 1

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8080)


### PR DESCRIPTION
## Summary
Fixes Google Cloud App Engine deployment issues that were causing 502 gateway errors.

## Problem
- App Engine couldn't find the main module 
- Missing entry point configuration for gunicorn
- Required Python module was excluded from deployment

## Solution
- Add `main.py` as entry point for gunicorn
- Configure gunicorn entrypoint in `app.yaml`
- Include `create_firewall_profile.py` in deployment (remove from .gcloudignore)

## Testing
Deployment has been tested and confirmed working on App Engine with these changes.